### PR TITLE
V1.2.0 - Add Vimeo Support

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -8,12 +8,11 @@
   "siteOptions": {
     "blogname": "Testing \"Enhanced Embed Block for YouTube\" plugin"
   },
-  "phpExtensionBundles": ["kitchen-sink"],
   "login": true,
   "steps": [
     {
       "step": "installPlugin",
-      "pluginZipFile": {
+      "pluginData": {
         "resource": "wordpress.org/plugins",
         "slug": "enhanced-embed-block"
       },

--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -6,7 +6,7 @@
     "wp": "latest"
   },
   "siteOptions": {
-    "blogname": "Testing \"Enhanced Embed Block for YouTube\" plugin"
+    "blogname": "Testing \"Enhanced Embed Block for YouTube & Vimeo\" plugin"
   },
   "login": true,
   "steps": [

--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
 # Enhanced Embed Block for YouTube
 
-A WordPress plugin for better user experience and faster page loads on any page with a YouTube video.
+A WordPress plugin for better user experience and faster page loads on any page with a YouTube or Vimeo video.
 
 Mark Root-Wiley, [MRW Web Design](https://MRWweb.com)
 
 ## What this plugin does
 
-This plugin makes the default WordPress YouTube Embed block infinitely better by replacing each video with the [`lite-youtube` custom element](https://github.com/justinribeiro/lite-youtube).
+This plugin makes the default WordPress YouTube and Vimeo Embed blocks infinitely better by replacing each video with the [`lite-youtube` custom element](https://github.com/justinribeiro/lite-youtube) or [`lite-vimeo` custom element](https://github.com/cshawaus/lite-vimeo), respectively.
 
 The plugin further improves things by providing a no-JS fallback and ensuring that the video placeholder doesn't cause a layout shift from when the page loads to when the custom element is initialized.
+
+## Open Source Credits
+
+- [`lite-youtube` custom-element](https://github.com/justinribeiro/lite-youtube) by @justinribeiro (MIT License)
+- [`lite-vimeo` custom-element](https://github.com/cshawaus/lite-vimeo) by @cshawaus (MIT License)
 
 ## See also
 

--- a/css/lite-embed-fallback.css
+++ b/css/lite-embed-fallback.css
@@ -1,17 +1,6 @@
-/*
- The "old-school" method of using padding-bottom does not work
- in combination with an element that relies on max-width.
-
- This more modern approach works in either context.
-*/
-lite-youtube {
-	display: block !important; /* required for layout if JS fails to load */
-	padding-bottom: 0 !important; /* remove old method of aspect ratio */
-	aspect-ratio: 16/9 !important;
-}
-
-.lite-youtube-fallback {
+.lite-embed-fallback {
 	--eeb-fallback-background: #000;
+	--eeb-focus-outline-color: red;
 
 	display: flex !important;
 	flex-direction: column !important;
@@ -23,36 +12,34 @@ lite-youtube {
 	padding: 5% !important;
 	background-color: var(--eeb-fallback-background) !important;
 	text-decoration: none !important;
-	transition: opacity 0.15s ease-in-out !important;
 }
 
-.lite-youtube-fallback:hover {
+.lite-embed-fallback:hover {
 	text-decoration: underline !important;
 }
-.lite-youtube-fallback:hover::before {
+.lite-embed-fallback:hover::before {
 	transform: scale(1.1) !important;
 }
 @media (prefers-reduced-motion: reduce) {
-	.lite-youtube-fallback:hover::before {
+	.lite-embed-fallback:hover::before {
 		transform: none !important;
 	}
 }
 
-.lite-youtube-fallback:focus-visible {
-	--eeb-focus-outline-color: red;
+.lite-embed-fallback:focus-visible {
 	outline: 2px solid var(--eeb-focus-outline-color) !important;
-	outline-offset: 3px !important;
+	outline-offset: -4px !important;
 }
 
-.lite-youtube-fallback,
-.lite-youtube-fallback:link,
-.lite-youtube-fallback:hover,
-.lite-youtube-fallback:focus,
-.lite-youtube-fallback:active {
+.lite-embed-fallback,
+.lite-embed-fallback:link,
+.lite-embed-fallback:hover,
+.lite-embed-fallback:focus,
+.lite-embed-fallback:active {
 	color: #fff !important;
 }
 
-.lite-youtube-fallback::before {
+.lite-embed-fallback::before {
 	display: block !important;
 	content: "" !important;
 	background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 68 48"><path d="M66.52 7.74c-.78-2.93-2.49-5.41-5.42-6.19C55.79.13 34 0 34 0S12.21.13 6.9 1.55c-2.93.78-4.63 3.26-5.42 6.19C.06 13.05 0 24 0 24s.06 10.95 1.48 16.26c.78 2.93 2.49 5.41 5.42 6.19C12.21 47.87 34 48 34 48s21.79-.13 27.1-1.55c2.93-.78 4.64-3.26 5.42-6.19C67.94 34.95 68 24 68 24s-.06-10.95-1.48-16.26z" fill="red"/><path d="M45 24 27 14v20" fill="white"/></svg>')
@@ -60,5 +47,16 @@ lite-youtube {
 	width: 68px !important;
 	height: 48px !important;
 	aspect-ratio: 94/67 !important;
+	transform: scale(1) translateZ(0) !important;
 	transition: 0.15s transform ease-in-out !important;
+}
+
+.is-provider-vimeo {
+	--ebb-focus-outline-color: #17D5FF;
+}
+
+.is-provider-vimeo .lite-embed-fallback::before {
+	background: #17D5ff url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 68 48"><path d="M45 24 27 14v20" fill="white"/></svg>')
+		center / cover no-repeat !important;
+	border-radius: 10%;
 }

--- a/enhanced-embed-block.php
+++ b/enhanced-embed-block.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Plugin Name:     Enhanced Embed Block for YouTube
+ * Plugin Name:     Enhanced Embed Block for YouTube & Vimeo
  * Plugin URI:      https://mrwweb.com/wordpress-plugins/enhanced-embed-block/
- * Description:     Enhance the default YouTube Embed block to load faster.
+ * Description:     Make the default YouTube and Vimeo Embed blocks load faster.
  * Author:          Mark Root-Wiley, MRW Web Design
  * Author URI:      https://MRWweb.com
  * Text Domain:     enhanced-embed-block

--- a/enhanced-embed-block.php
+++ b/enhanced-embed-block.php
@@ -9,6 +9,8 @@
  * Version:         1.1.0
  * Requires at least: 6.5
  * Requires PHP:    7.4
+ * GitHub Plugin URI: mrwweb/mrw-post-cleanup-utilities
+ * Primary Branch:  main
  * License:         GPLv3 or later
  * License URI:     https://www.gnu.org/licenses/gpl-3.0.html
  *

--- a/enhanced-embed-block.php
+++ b/enhanced-embed-block.php
@@ -35,7 +35,7 @@ function enqueue_lite_youtube_component() {
 		plugins_url( 'vendor/lite-youtube/lite-youtube.js', __FILE__ ),
 		array(),
 		'1.5.0',
-		array( 'in_footer' => true )
+		array( 'async' => true )
 	);
 }
 

--- a/enhanced-embed-block.php
+++ b/enhanced-embed-block.php
@@ -175,6 +175,8 @@ function extract_youtube_id_from_uri( $uri ) {
  */
 function extract_start_time_from_uri( $uri ) {
 	$params = wp_parse_url( $uri, PHP_URL_QUERY );
-	parse_str( $params, $query );
+	if( !empty($params) ) {
+		parse_str( $params, $query );
+	}
 	return $query['t'] ?? false;
 }

--- a/enhanced-embed-block.php
+++ b/enhanced-embed-block.php
@@ -6,10 +6,10 @@
  * Author:          Mark Root-Wiley, MRW Web Design
  * Author URI:      https://MRWweb.com
  * Text Domain:     enhanced-embed-block
- * Version:         1.1.0
+ * Version:         1.2.0
  * Requires at least: 6.5
  * Requires PHP:    7.4
- * GitHub Plugin URI: mrwweb/mrw-post-cleanup-utilities
+ * GitHub Plugin URI: mrwweb/enhanced-embed-block
  * Primary Branch:  main
  * License:         GPLv3 or later
  * License URI:     https://www.gnu.org/licenses/gpl-3.0.html
@@ -19,9 +19,7 @@
 
 namespace EnhancedEmbedBlock;
 
-use WP_HTML_TAG_Processor;
-
-define( 'EEB_VERSION', '1.1.0' );
+define( 'EEB_VERSION', '1.2.0' );
 
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_lite_youtube_component' );
 /**
@@ -34,29 +32,32 @@ function enqueue_lite_youtube_component() {
 		'lite-youtube',
 		plugins_url( 'vendor/lite-youtube/lite-youtube.js', __FILE__ ),
 		array(),
-		'1.5.0',
+		'1.8.1',
 		array( 'async' => true )
+	);
+
+	wp_register_script_module(
+		'lite-vimeo',
+		plugins_url( 'vendor/lite-vimeo/lite-vimeo.js', __FILE__ ),
+		array(),
+		'1.0.2',
+		array( 'async' => true )
+	);
+
+	wp_register_style(
+		'lite-embed-fallback',
+		plugins_url( 'css/lite-embed-fallback.css', __FILE__ ),
+		array(),
+		EEB_VERSION,
 	);
 }
 
-add_action( 'after_setup_theme', __NAMESPACE__ . '\enqueue_embed_block_style' );
-function enqueue_embed_block_style() {
-	wp_enqueue_block_style(
-		'core/embed',
-		array(
-			'handle' => 'lite-youtube-custom',
-			'src'    => plugins_url( 'css/lite-youtube-custom.css', __FILE__ ),
-			'path'   => plugin_dir_path( __FILE__ ) . '/css/lite-youtube-custom.css',
-			'ver'    => EEB_VERSION,
-		)
-	);
-}
 
 
 /* Pre-2020 Blocks */
-add_filter( 'render_block_core-embed/youtube', __NAMESPACE__ . '\replace_youtube_embed_with_web_component', 10, 2 );
+add_filter( 'render_block_core-embed/youtube', __NAMESPACE__ . '\replace_embeds_with_web_components', 10, 2 );
 /* 2020-onward Block */
-add_filter( 'render_block_core/embed', __NAMESPACE__ . '\replace_youtube_embed_with_web_component', 10, 2 );
+add_filter( 'render_block_core/embed', __NAMESPACE__ . '\replace_embeds_with_web_components', 10, 2 );
 /**
  * Filter the Embed output and replace it with the web component
  *
@@ -64,121 +65,35 @@ add_filter( 'render_block_core/embed', __NAMESPACE__ . '\replace_youtube_embed_w
  * @param array  $block The block attributes.
  * @return string HTML for embed block
  */
-function replace_youtube_embed_with_web_component( $content, $block ) {
-	$isValidYouTube = 'youtube' === $block['attrs']['providerNameSlug'] && isset( $block['attrs']['url'] );
-	if( ! $isValidYouTube || is_feed() ) {
+function replace_embeds_with_web_components( $content, $block ) {
+
+	if (
+		! isset( $block['attrs']['url'] ) ||
+		is_feed() ||
+		! in_array(
+			$block['attrs']['providerNameSlug'],
+			array( 'youtube', 'vimeo' ),
+			true
+		)
+	) {
 		return $content;
 	}
 
-	$video_id = extract_youtube_id_from_uri( $block['attrs']['url'] );
-	if ( ! $video_id ) {
-		return $content;
+	wp_enqueue_style( 'lite-embed-fallback' );
+
+	switch ( $block['attrs']['providerNameSlug'] ) {
+		case 'youtube':
+			$content = render_youtube_embed( $content, $block );
+			break;
+
+		case 'vimeo':
+			$content = render_vimeo_embed( $content, $block );
+			break;
 	}
-
-	wp_enqueue_script_module( 'lite-youtube' );
-
-	$video_title   = extract_title_from_embed_code( $content );
-	$start_time    = extract_start_time_from_uri( $block['attrs']['url'] );
-	$embed_caption = extract_figcaption_from_embed_code( $content );
-
-	/* translators: %s: title from YouTube video */
-	$play_button = sprintf( __( 'Play: %s', 'enhanced-embed-block' ), $video_title );
-
-	/**
-	 * Filter the poster quality for the YouTube preview thumbnail
-	 * 
-	 * @since 1.1.0
-	 * @param string $quality One of mqdefault, hqdefault, sddefault, or maxresdefault (default)
-	 */
-	$poster_quality = apply_filters( 'eeb_posterquality', 'maxresdefault' );
-
-	/**
-	 * Filter to determine whether to load embed from nocookie YouTube domain
-	 * 
-	 * @since 1.1.0
-	 * @param bool $use_nocookie Whether to use the nocookie domain (default: true)
-	 */
-	$nocookie = apply_filters( 'eeb_nocookie', true );
-
-	/* Craft the new output: the web component with HTML fallback link */
-	$content = sprintf(
-		'<figure class="wp-block-embed-youtube wp-block-embed is-type-video is-provider-youtube">
-			<div class="wp-block-embed__wrapper">
-				<lite-youtube videoid="%1$s" videoplay="%2$s" videoStartAt="%3$d" posterquality="%4$s" posterloading="lazy"%5$s>
-					<a href="%6$s" class="lite-youtube-fallback" target="_blank" rel="noreferrer noopenner">Watch "%7$s" on YouTube</a>
-				</lite-youtube>
-			</div>
-			%8$s
-		</figure>',
-		esc_attr( $video_id ),
-		esc_attr( $play_button ),
-		$start_time ? intval( $start_time ) : 0,
-		in_array( $poster_quality, array( 'mqdefault', 'hqdefault', 'sddefault', 'maxresdefault' ), true ) ? $poster_quality : 'maxresdefault',
-		$nocookie ? ' nocookie' : '',
-		esc_url( $block['attrs']['url'] ),
-		esc_html( $video_title ),
-		$embed_caption
-	);
 
 	return $content;
 }
 
-/**
- * Extract the value of the title attribute from HTML that contains an iframe of an existing YouTube embed code
- *
- * @param string $html A block of HTML containing a YouTube iframe.
- * @return string the title attribute valube
- */
-function extract_title_from_embed_code( $html ) {
-	$processor = new WP_HTML_TAG_Processor( $html );
-	$processor->next_tag( 'iframe' );
-	$title = $processor->get_attribute( 'title' );
-
-	return $title;
-}
-
-/**
- * Extract the figcaption from the embed code
- *
- * @param string $html A block of HTML containing a YouTube iframe.
- * @return string The figcaption OR an empty string
- * 
- * @todo Replace this with HTML Tag Processor, if possible
- */
-function extract_figcaption_from_embed_code( $html ) {
-	preg_match( '/<figcaption(.*?)<\/figcaption>/s', $html, $match );
-	return isset( $match[0] ) ? $match[0] : false;
-}
-
-/**
- * Get the YouTube video ID from a YouTube video URL, either the default youtube.com one or the shortened youtu.be one
- *
- * @param string $uri A YouTube video URL.
- * @return string video ID for a YouTube video
- */
-function extract_youtube_id_from_uri( $uri ) {
-	$host = wp_parse_url( $uri, PHP_URL_HOST );
-
-	/* Handle Shortlinks */
-	if ( 'youtu.be' === $host ) {
-		return ltrim( wp_parse_url( $uri, PHP_URL_PATH ), '/' );
-	}
-
-	$params = wp_parse_url( $uri, PHP_URL_QUERY );
-	parse_str( $params, $query );
-	return $query['v'] ?? false;
-}
-
-/**
- * Extract the start time parameter "t" from  YouTube video URL
- *
- * @param string $uri URL of YouTube video that may or may not contain a start time parameter.
- * @return string|bool The value of the t parameter or false if it isn't present
- */
-function extract_start_time_from_uri( $uri ) {
-	$params = wp_parse_url( $uri, PHP_URL_QUERY );
-	if( !empty($params) ) {
-		parse_str( $params, $query );
-	}
-	return $query['t'] ?? false;
-}
+require_once plugin_dir_path( __FILE__ ) . 'inc/generic.php';
+require_once plugin_dir_path( __FILE__ ) . 'inc/vimeo.php';
+require_once plugin_dir_path( __FILE__ ) . 'inc/youtube.php';

--- a/inc/generic.php
+++ b/inc/generic.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Generic helper functions
+ *
+ * @package         Enhanced_Embed_Block
+ */
+
+namespace EnhancedEmbedBlock;
+
+use WP_HTML_TAG_Processor;
+
+/**
+ * Extract the value of the title attribute from HTML that contains an iframe of an existing YouTube embed code
+ *
+ * @param string $html A block of HTML containing a YouTube iframe.
+ * @return string the title attribute valube
+ */
+function extract_title_from_embed_code( $html ) {
+	$processor = new WP_HTML_TAG_Processor( $html );
+	$processor->next_tag( 'iframe' );
+	$title = $processor->get_attribute( 'title' );
+
+	return $title;
+}
+
+/**
+ * Extract the figcaption from the embed code
+ *
+ * @param string $html A block of HTML containing a YouTube iframe.
+ * @return string The figcaption OR an empty string
+ *
+ * @todo Replace this with HTML Tag Processor, if possible
+ */
+function extract_figcaption_from_embed_code( $html ) {
+	preg_match( '/<figcaption(.*?)<\/figcaption>/s', $html, $match );
+	return isset( $match[0] ) ? $match[0] : false;
+}

--- a/inc/vimeo.php
+++ b/inc/vimeo.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Vimeo helper functions
+ *
+ * @package         Enhanced_Embed_Block
+ */
+
+namespace EnhancedEmbedBlock;
+
+use WP_HTML_TAG_Processor;
+
+/**
+ * Attempts to replace Vimeo iframe in embed block with lite-vimeo web component
+ *
+ * @param string $content embed block's content.
+ * @param array  $block block attributes.
+ * @return string HTML block content, possibly with modified HTML
+ */
+function render_vimeo_embed( $content, $block ) {
+	$video_id = extract_vimeo_id( $block['attrs']['url'], $content );
+
+	if ( ! $video_id ) {
+		return $content;
+	}
+
+	wp_enqueue_script_module( 'lite-vimeo' );
+
+	$video_title   = extract_title_from_embed_code( $content );
+	$start_time    = extract_start_time_from_vimeo_uri( $block['attrs']['url'] );
+	$embed_caption = extract_figcaption_from_embed_code( $content );
+
+	/* translators: %s: title from YouTube video */
+	$play_button = __( 'Play', 'enhanced-embed-block' );
+
+	/* Craft the new output: the web component with HTML fallback link */
+	$content = sprintf(
+		'<figure class="wp-block-embed-vimeo wp-block-embed is-type-video is-provider-vimeo">
+			<div class="wp-block-embed__wrapper">
+				<lite-vimeo videoid="%1$s" videotitle="%2$s" videoplay="%3$s" start="%4$ds">
+					<a href="%5$s" class="lite-embed-fallback" target="_blank" rel="noreferrer noopenner">Watch "%2$s" on Vimeo</a>
+				</lite-vimeo>
+			</div>
+			%6$s
+		</figure>',
+		esc_attr( $video_id ),
+		esc_html( $video_title ),
+		esc_html( $play_button ),
+		$start_time,
+		esc_url( $block['attrs']['url'] ),
+		$embed_caption
+	);
+
+	return $content;
+}
+
+/**
+ * Get the Vimeo video ID from a Vimeo video URL
+ *
+ * @param string $uri A Vimeo video URL.
+ * @param string $content The HTML content of the block.
+ * @return string|bool video ID for a Vimeo video or false
+ */
+function extract_vimeo_id( $uri, $content ) {
+	$path = explode( '/', wp_parse_url( $uri, PHP_URL_PATH ) );
+
+	$id = array_pop( $path ) ?? false;
+
+	if ( is_numeric( $id ) ) {
+		return $id;
+	} else {
+		$processor = new WP_HTML_TAG_Processor( $content );
+		$processor->next_tag( 'iframe' );
+		$uri = $processor->get_attribute( 'src' );
+
+		$path = explode( '/', wp_parse_url( $uri, PHP_URL_PATH ) );
+
+		return array_pop( $path ) ?? false;
+	}
+}
+
+/**
+ * Extract the start time fragment "t" from Vimeo video URL
+ *
+ * @param string $uri URL of Vimeo video that may or may not contain a start time parameter.
+ * @return string|bool The value of the t parameter or false if it isn't present
+ */
+function extract_start_time_from_vimeo_uri( $uri ) {
+	$params = wp_parse_url( $uri, PHP_URL_FRAGMENT );
+	if ( ! empty( $params ) ) {
+		parse_str( $params, $query );
+	}
+	return $query['t'] ?? 0;
+}

--- a/inc/youtube.php
+++ b/inc/youtube.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * YouTube helper functions
+ *
+ * @package         Enhanced_Embed_Block
+ */
+
+namespace EnhancedEmbedBlock;
+
+/**
+ * Attempts to replace YouTube iframe in embed block with lite-youtube web component
+ *
+ * @param string $content embed block's content.
+ * @param array  $block block attributes.
+ * @return string HTML block content, possibly with modified HTML
+ */
+function render_youtube_embed( $content, $block ) {
+	$video_id = extract_youtube_id_from_uri( $block['attrs']['url'] );
+	if ( ! $video_id ) {
+		return $content;
+	}
+
+	wp_enqueue_script_module( 'lite-youtube' );
+
+	$video_title   = extract_title_from_embed_code( $content );
+	$start_time    = extract_start_time_from_youtube_uri( $block['attrs']['url'] );
+	$embed_caption = extract_figcaption_from_embed_code( $content );
+
+	/* translators: %s: title from YouTube video */
+	$play_button = sprintf( __( 'Play: %s', 'enhanced-embed-block' ), $video_title );
+
+	/**
+	 * Filter the poster quality for the YouTube preview thumbnail
+	 *
+	 * @since 1.1.0
+	 * @param string $quality One of mqdefault, hqdefault, sddefault, or maxresdefault (default)
+	 */
+	$poster_quality = apply_filters( 'eeb_posterquality', 'maxresdefault' );
+
+	/**
+	 * Filter to determine whether to load embed from nocookie YouTube domain
+	 *
+	 * @since 1.1.0
+	 * @param bool $use_nocookie Whether to use the nocookie domain (default: true)
+	 */
+	$nocookie = apply_filters( 'eeb_nocookie', true );
+
+	/* Craft the new output: the web component with HTML fallback link */
+	$content = sprintf(
+		'<figure class="wp-block-embed-youtube wp-block-embed is-type-video is-provider-youtube">
+			<div class="wp-block-embed__wrapper">
+				<lite-youtube videoid="%1$s" videotitle="%7$s" videoplay="%2$s" videoStartAt="%3$d" posterquality="%4$s" posterloading="lazy"%5$s disablenoscript>
+					<a href="%6$s" class="lite-embed-fallback" target="_blank" rel="noreferrer noopenner">Watch "%7$s" on YouTube</a>
+				</lite-youtube>
+			</div>
+			%8$s
+		</figure>',
+		esc_attr( $video_id ),
+		esc_attr( $play_button ),
+		$start_time ? intval( $start_time ) : 0,
+		in_array( $poster_quality, array( 'mqdefault', 'hqdefault', 'sddefault', 'maxresdefault' ), true ) ? $poster_quality : 'maxresdefault',
+		$nocookie ? ' nocookie ' : '',
+		esc_url( $block['attrs']['url'] ),
+		esc_html( $video_title ),
+		$embed_caption
+	);
+
+	return $content;
+}
+
+/**
+ * Get the YouTube video ID from a YouTube video URL, either the default youtube.com one or the shortened youtu.be one
+ *
+ * @param string $uri A YouTube video URL.
+ * @return string video ID for a YouTube video
+ */
+function extract_youtube_id_from_uri( $uri ) {
+	$host = wp_parse_url( $uri, PHP_URL_HOST );
+
+	/* Handle Shortlinks */
+	if ( 'youtu.be' === $host ) {
+		return ltrim( wp_parse_url( $uri, PHP_URL_PATH ), '/' );
+	}
+
+	$params = wp_parse_url( $uri, PHP_URL_QUERY );
+	parse_str( $params, $query );
+	return $query['v'] ?? false;
+}
+
+/**
+ * Extract the start time parameter "t" from YouTube video URL
+ *
+ * @param string $uri URL of YouTube video that may or may not contain a start time parameter.
+ * @return string|bool The value of the t parameter or false if it isn't present
+ */
+function extract_start_time_from_youtube_uri( $uri ) {
+	$params = wp_parse_url( $uri, PHP_URL_QUERY );
+	if ( ! empty( $params ) ) {
+		parse_str( $params, $query );
+	}
+	return $query['t'] ?? false;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,25 @@
       "name": "enhanced-embed-block",
       "version": "0.1.0",
       "devDependencies": {
-        "@justinribeiro/lite-youtube": "^1.5.0"
+        "@cshawaus/lite-vimeo": "^1.0.2",
+        "@justinribeiro/lite-youtube": "^1.8.1"
+      }
+    },
+    "node_modules/@cshawaus/lite-vimeo": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@cshawaus/lite-vimeo/-/lite-vimeo-1.0.2.tgz",
+      "integrity": "sha512-m512WiewFb3tlsIkAj1CO2wqISz0i8DHdzPAZRi1/tnWnp/dpK3zbekBS1RCIxIyS+Pri/tY25djXnOg7O+Asw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">= 22",
+        "pnpm": ">= 10"
       }
     },
     "node_modules/@justinribeiro/lite-youtube": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@justinribeiro/lite-youtube/-/lite-youtube-1.8.0.tgz",
-      "integrity": "sha512-gUD2t+vCKnS8Ctf0QKGOEVkgk1aQDoRuB5arBOUJHbTy2ILtwGwKlf9cLY40jZp0FWxlv+ku4aviV3FPYKQY5w==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@justinribeiro/lite-youtube/-/lite-youtube-1.8.1.tgz",
+      "integrity": "sha512-b64RclJsQoONgIjayk/2wPqwrCdxcb2ZBR49cS6Tgt858vj7eKJYhekwgYBRn61tDDflkYedK+KOkrdBZVnwRQ==",
       "dev": true
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,21 @@
 {
-  "name": "lite-embed-for-youtube",
+  "name": "enhanced-embed-block",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "lite-embed-for-youtube",
+      "name": "enhanced-embed-block",
       "version": "0.1.0",
-      "dependencies": {
+      "devDependencies": {
         "@justinribeiro/lite-youtube": "^1.5.0"
       }
     },
     "node_modules/@justinribeiro/lite-youtube": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@justinribeiro/lite-youtube/-/lite-youtube-1.5.0.tgz",
-      "integrity": "sha512-TU92RKtz9BI9PRYrVwDIUsnFadLZtqRKWl1ZOdbxb7roJDb8Dd/xURllAsLEmCg6oJNyhXlVa5RsnUc0EKd8Cw=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@justinribeiro/lite-youtube/-/lite-youtube-1.8.0.tgz",
+      "integrity": "sha512-gUD2t+vCKnS8Ctf0QKGOEVkgk1aQDoRuB5arBOUJHbTy2ILtwGwKlf9cLY40jZp0FWxlv+ku4aviV3FPYKQY5w==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "version": "0.1.0",
   "author": "Mark Root-Wiley",
   "devDependencies": {
-    "@justinribeiro/lite-youtube": "^1.5.0"
+    "@cshawaus/lite-vimeo": "^1.0.2",
+    "@justinribeiro/lite-youtube": "^1.8.1"
   },
   "scripts": {
-    "update-lite-youtube": "cp node_modules/@justinribeiro/lite-youtube/lite-youtube.js vendor/lite-youtube/; cp node_modules/@justinribeiro/lite-youtube/README.md vendor/lite-youtube/; cp node_modules/@justinribeiro/lite-youtube/LICENSE vendor/lite-youtube/"
+    "update-lite-youtube": "cp node_modules/@justinribeiro/lite-youtube/lite-youtube.js vendor/lite-youtube/ && cp node_modules/@justinribeiro/lite-youtube/README.md vendor/lite-youtube/ && cp node_modules/@justinribeiro/lite-youtube/LICENSE vendor/lite-youtube/",
+    "update-lite-vimeo": "cp node_modules/@cshawaus/lite-vimeo/lib/index.js vendor/lite-vimeo/ && mv vendor/lite-vimeo/index.js vendor/lite-vimeo/lite-vimeo.js && cp node_modules/@cshawaus/lite-vimeo/README.md vendor/lite-vimeo/ && cp node_modules/@cshawaus/lite-vimeo/LICENSE vendor/lite-vimeo/"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
     "@justinribeiro/lite-youtube": "^1.5.0"
   },
   "scripts": {
-    "update-lite-youtube": "cp node_modules/@justinribeiro/lite-youtube/lite-youtube.js vendor/lite-youtube/; cp node_modules/@justinribeiro/lite-youtube/README.md vendor/lite-youtube; cp node_modules/@justinribeiro/lite-youtube/LICENSE vendor/lite-youtube"
+    "update-lite-youtube": "cp node_modules/@justinribeiro/lite-youtube/lite-youtube.js vendor/lite-youtube/; cp node_modules/@justinribeiro/lite-youtube/README.md vendor/lite-youtube/; cp node_modules/@justinribeiro/lite-youtube/LICENSE vendor/lite-youtube/"
   }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -84,9 +84,11 @@ This plugin uses the [`lite-vimeo` custom-element](https://github.com/cshawaus/l
 == Changelog ==
 
 = 1.2.0 (14 May 2025) =
+
 - Add support for Vimeo!
 - Upgrade `lite-youtube` to 1.8.1 (includes new native support for fallback thumbnail formats and sizes)
 - Further performance improvements to load script asynchronously and only load styles when needed
+- Fix undefined $params fatal error when trying to extract time code from YouTube URLs
 - Code quality improvements
 
 = 1.1.0 (11 July 2024) =

--- a/readme.txt
+++ b/readme.txt
@@ -1,28 +1,29 @@
-=== Enhanced Embed Block for YouTube ===
+=== Enhanced Embed Block for YouTube & Vimeo ===
 Contributors: mrwweb, cbirdsong
 Donate link: https://paypal.me/rootwiley
-Tags: YouTube, embed, video, block, performance
+Tags: YouTube, Vimeo, embed, video, block
 Requires at least: 6.5
-Tested up to: 6.6
+Tested up to: 6.8
 Requires PHP: 7.4
-Stable tag: 1.1.0
+Stable tag: 1.2.0
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
-Enhance the default YouTube Embed Block to load faster.
+Enhance the default YouTube and Vimeo Embed blocks to load faster.
 
 == Description ==
 
 If you care about performance, privacy, and user experience, this block is for you.
 
-This plugin enhances the default YouTube block—including any existing blocks—and changes their behavior to only load the video thumbnail until a visitor chooses to play the video.
+This plugin enhances the default YouTube and Vimeo blocks—including any existing blocks—and changes their behavior to only load the video thumbnail until a visitor chooses to play the video.
 
 = Features =
 
 * Load YouTube videos faster (uses the `lite-youtube` custom-element)
-* Loads videos from nocookie.youtube.com for enhanced privacy
-* Works without JavaScript (shows link to YouTube video instead)
-* No plugin lock-in! Automatically improves all YouTube embeds. Turn it off and the behavior goes back to the WordPress default.
+* Load Vimeo videos faster (uses the `lite-viemo` custom-element)
+* Loads YouTube videos from nocookie.youtube.com for enhanced privacy
+* Works without JavaScript (shows link to video instead in a player-like design)
+* No plugin lock-in! Automatically improves the core Embed block. Turn the plugin off and the behavior goes back to the WordPress default.
 
 = Want more features? =
 
@@ -37,7 +38,6 @@ I'm considering building a PRO version with the potential following features:
 * Support for playlists, not just single videos
 * Full support for all YouTube query parameters (https://developers.google.com/youtube/player_parameters)
 * Classic Editor / [embed] shortcode support
-* Support similar features for Vimeo and other embed sources where possible
 
 If enough people express interest, I'll build it! [Let me know if you're interested!](https://mrwweb.com/wordpress-plugins/enhanced-embed-block/#pro)
 
@@ -48,7 +48,7 @@ If enough people express interest, I'll build it! [Let me know if you're interes
 == Installation ==
 
 1. From your WordPress site’s dashboard, go to Plugins > Add New.
-2. Search for “Enhanced Embed Block for YouTube”
+2. Search for “Enhanced Embed Block for YouTube and Vimeo”
 3. Click “Install”
 4. Click “Activate”
 5. That’s it! You’re done! There are no plugin settings and the enhancements immediately apply to all YouTube video embeds.
@@ -57,13 +57,13 @@ If enough people express interest, I'll build it! [Let me know if you're interes
 
 = Does this create a new block? =
 
-No. It enhances the default WordPress embed block for YouTube videos.
+No. It enhances the default WordPress Embed block for YouTube and Vimeo videos.
 
-= Does it automatically enhance all my YouTube embeds? =
+= Does it automatically enhance all my YouTube and Vimeo embeds? =
 
-It works for any embeds using the YouTube block. Embeds using the [embed] shortcode or literal YouTube embed code in HTML are not enhanced. Using the core WordPress YouTube Embed block is highly recommended!
+It works for any embeds using the YouTube or Vimeo variations of the Embed block. Embeds using the [embed] shortcode or literal YouTube embed code in HTML are not enhanced. Using the core WordPress Embed block is highly recommended!
 
-= Why doesn't Google load all videos this way by default? =
+= Why don't Google and Vimeo load all their videos this way by default? =
 
 Great question! It sure seems like they should. If I had to guess, they are prioritizing usage tracking over fast load times and privacy.
 
@@ -79,9 +79,18 @@ Not right now. If you'd pay for a PRO version with this feature, [let me know](h
 
 This plugin uses the [`lite-youtube` custom-element](https://github.com/justinribeiro/lite-youtube) under the MIT license. Thank you to Paul Irish and Justin Ribiero for their work on that project.
 
+This plugin uses the [`lite-vimeo` custom-element](https://github.com/cshawaus/lite-vimeo) under the MIT license. Thank you to Chris Shaw for their work on that project.
+
 == Changelog ==
 
-= 1.1.0 =
+= 1.2.0 (14 May 2025) =
+- Add support for Vimeo!
+- Upgrade `lite-youtube` to 1.8.1 (includes new native support for fallback thumbnail formats and sizes)
+- Further performance improvements to load script asynchronously and only load styles when needed
+- Code quality improvements
+
+= 1.1.0 (11 July 2024) =
+
 - Fix missing file on WordPress.org version of plugin due to misconfigured Github deployment
 - MAJOR CHANGE: The default poster image is now the highest quality possible. There is a new `eeb_posterquality` filter to change that, if desired. (#5)
 - Add experimental patch to the `lite-youtube` web component that detects missing YouTube poster images and fallsback to different format / lower quality (#4)
@@ -90,10 +99,11 @@ This plugin uses the [`lite-youtube` custom-element](https://github.com/justinri
 - Don't use lite-youtube embed in feeds (#9)
 - Props to @cbirdsong for numerous issues on Github that led to most of these changes
 
-= 1.0.0 =
+= 1.0.0 (22 April 2024) =
+
 - Initial release to the WordPress repository!
 
 == Upgrade Notice ==
 
-= 1.1.0 =
-Fix plugin in WordPress repository. Use higher quality poster image with new fallback detection. Don't apply embed changes to feeds. Developer improvements.
+= 1.2.0 =
+Add Vimeo support! Upgrade lite-youtube custom element. Even faster loading times.

--- a/vendor/lite-vimeo/LICENSE
+++ b/vendor/lite-vimeo/LICENSE
@@ -1,0 +1,23 @@
+MIT License
+
+Copyright (c) 2023 Chris Shaw
+Copyright (c) 2023 Alex Russell
+Copyright (c) 2019 Justin Ribeiro
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/lite-vimeo/README.md
+++ b/vendor/lite-vimeo/README.md
@@ -1,0 +1,154 @@
+# \<lite-vimeo\>
+
+<p>
+  <a href="https://npmjs.com/package/@cshawaus/lite-vimeo"><img src="https://img.shields.io/npm/v/@cshawaus/lite-vimeo.svg" alt="npm package"></a>
+  <a href="https://nodejs.org/en/about/releases/"><img src="https://img.shields.io/node/v/@cshawaus/lite-vimeo.svg" alt="node compatility"></a>
+</p>
+
+> A web component that displays Vimeo embeds faster. Based on Justin Ribeiro's excellent [\<lite-youtube\>](https://github.com/justinribeiro/lite-youtube), which, in turn, is a shadow DOM version of Paul's [lite-youtube-embed](https://github.com/paulirish/lite-youtube-embed) based on Alex Russell's [\<lite-vimeo\>](https://github.com/cshawaus/lite-vimeo/) package.
+
+This is basically a rebadge of Justin's component, but for Vimeo.
+
+## Features
+
+- No dependencies; it's just a vanilla web component.
+- It's fast yo.
+- It's shadow DOM encapsulated! (supports CSS `::part`)
+- It's responsive 16:9
+- It's accessible via keyboard and will set ARIA via the `videotitle` attribute
+- It's locale ready; you can set the `videoplay` to have a properly locale based label
+- Set the `start` attribute to start at a particular place in a video
+- You can set `autoload` to use Intersection Observer to load the iframe when scrolled into view.
+- Loads placeholder image as WebP with a Jpeg fallback
+
+## Install
+
+This web component is built with ES modules in mind and is
+available on NPM.
+
+```sh
+pnpm i @cshawaus/lite-vimeo
+# or
+npm i @cshawaus/lite-vimeo
+# or
+yarn add @cshawaus/lite-vimeo
+```
+
+After installing import into your project using the following:
+
+```js
+import '@cshawaus/lite-vimeo'
+```
+
+## Usage with CommonJS
+
+CommonJS is supported for those who aren't ready to adopt ESM yet.
+
+```js
+require('@cshawaus/lite-vimeo')
+```
+
+## Usage with jsDelivr
+
+If you want the paste-and-go version, you can simply load it via jsDelivr.
+
+```html
+<!-- always the latest version -->
+<script src="https://cdn.jsdelivr.net/npm/@cshawaus/lite-vimeo/lib/index.js"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/@cshawaus/lite-vimeo/lib/index.esm.js"></script>
+
+<!-- pinned to a specific version -->
+<script src="https://cdn.jsdelivr.net/npm/@cshawaus/lite-vimeo@1.0.0/lib/index.js"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/@cshawaus/lite-vimeo@1.0.0/lib/index.esm.js"></script>
+```
+
+## Basic Usage
+
+```html
+<lite-vimeo videoid="364402896"></lite-vimeo>
+```
+
+## Add Video Title
+
+```html
+<lite-vimeo videoid="364402896" videotitle="This is a video title"></lite-vimeo>
+```
+
+## Change "Play" for Locale</h3>
+
+```html
+<lite-vimeo videoid="364402896" videoplay="Mirar" videotitle="Mis hijos se burlan de mi español"></lite-vimeo>
+```
+
+## Customise Everything
+
+Bring your own CSS to the party anc customise the web component to your liking.
+
+```html
+<style>
+  .vimeo-player {
+    margin: auto;
+    max-width: 1024px;
+    width: 100%;
+  }
+</style>
+<div class="vimeo-player">
+  <lite-vimeo videoid="364402896"></lite-vimeo>
+</div>
+```
+
+### Using shadow DOM `::part`
+
+Because the shadow DOM exists outside of the normal page context it prevent global CSS from being applied. To overcome this you can make use of the `::part` CSS pseudo-element that can traverse the shadow tree and apply styles from the global context.
+
+```css
+.vimeo-player ::part(frame) {
+  border: 2px solid red;
+}
+```
+
+#### Available parts
+
+| CSS pseudo-element      | Description                                |
+| ----------------------- | ------------------------------------------ |
+| `::part(frame)`         | Targets the main player frame              |
+| `::part(picture-frame)` | Targets the `<picture>` element            |
+| `::part(picture)`       | Targets the `<img>` element in `<picture>` |
+| `::part(play-button)`   | Targets the play button                    |
+
+## Set a video start time
+
+```html
+<!-- Start at 5 min, 30 seconds -->
+<lite-vimeo videoid="364402896" start="5m30s"></lite-vimeo>
+```
+
+## Auto load with `IntersectionObserver`
+
+`IntersectionObserver` is used to automatically load the Vimeo iframe when scrolled into view. This can reduce performance in some circumstances with multiple players on the same page.
+
+```html
+<lite-vimeo videoid="364402896" autoload></lite-vimeo>
+```
+
+## Auto Play (requires auto load)
+
+When allowed by the browser the player will automatically start the vido upon it coming into view.
+
+```html
+<lite-vimeo videoid="364402896" autoload autoplay></lite-vimeo>
+```
+
+## Attributes
+
+The web component allows certain attributes to be give a little additional
+flexibility.
+
+| Name         | Description                                                                 | Default |
+| ------------ | --------------------------------------------------------------------------- | ------- |
+| `videoid`    | The Vimeo videoid                                                           | ``      |
+| `videotitle` | The title of the video                                                      | `Video` |
+| `videoplay`  | The title of the play button (for translation)                              | `Play`  |
+| `autoload`   | Use Intersection Observer to load iframe when scrolled into view            | `false` |
+| `autoplay`   | Video attempts to play automatically if auto-load set and browser allows it | `false` |
+| `start`      | Set the point at which the video should start, in seconds                   | `0`     |

--- a/vendor/lite-vimeo/lite-vimeo.js
+++ b/vendor/lite-vimeo/lite-vimeo.js
@@ -1,0 +1,294 @@
+"use strict";
+(() => {
+  // src/index.ts
+  var _LiteVimeoEmbed = class _LiteVimeoEmbed extends HTMLElement {
+    constructor() {
+      super();
+      this.iframeLoaded = false;
+      this.setupDom();
+    }
+    static get observedAttributes() {
+      return ["videoid"];
+    }
+    connectedCallback() {
+      this.addEventListener("pointerover", _LiteVimeoEmbed.warmConnections, {
+        once: true
+      });
+      this.addEventListener("click", () => this.addIframe());
+    }
+    get videoId() {
+      return encodeURIComponent(this.getAttribute("videoid") || "");
+    }
+    set videoId(id) {
+      this.setAttribute("videoid", id);
+    }
+    get videoTitle() {
+      return this.getAttribute("videotitle") || "Video";
+    }
+    set videoTitle(title) {
+      this.setAttribute("videotitle", title);
+    }
+    get videoPlay() {
+      return this.getAttribute("videoPlay") || "Play";
+    }
+    set videoPlay(name) {
+      this.setAttribute("videoPlay", name);
+    }
+    get videoStartAt() {
+      return this.getAttribute("start") || "0s";
+    }
+    set videoStartAt(time) {
+      this.setAttribute("start", time);
+    }
+    get autoLoad() {
+      return this.hasAttribute("autoload");
+    }
+    set autoLoad(value) {
+      if (value) {
+        this.setAttribute("autoload", "");
+      } else {
+        this.removeAttribute("autoload");
+      }
+    }
+    get autoPlay() {
+      return this.hasAttribute("autoplay");
+    }
+    set autoPlay(value) {
+      if (value) {
+        this.setAttribute("autoplay", "autoplay");
+      } else {
+        this.removeAttribute("autoplay");
+      }
+    }
+    /**
+     * Define our shadowDOM for the component
+     */
+    setupDom() {
+      const shadowDom = this.attachShadow({ mode: "open" });
+      shadowDom.innerHTML = `
+      <style>
+        :host {
+          contain: content;
+          display: block;
+          position: relative;
+          width: 100%;
+          padding-bottom: calc(100% / (16 / 9));
+        }
+
+        #frame, #fallbackPlaceholder, iframe {
+          position: absolute;
+          width: 100%;
+          height: 100%;
+        }
+
+        #frame {
+          cursor: pointer;
+        }
+
+        #fallbackPlaceholder {
+          object-fit: cover;
+        }
+
+        #frame::before {
+          content: '';
+          display: block;
+          position: absolute;
+          top: 0;
+          background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAADGCAYAAAAT+OqFAAAAdklEQVQoz42QQQ7AIAgEF/T/D+kbq/RWAlnQyyazA4aoAB4FsBSA/bFjuF1EOL7VbrIrBuusmrt4ZZORfb6ehbWdnRHEIiITaEUKa5EJqUakRSaEYBJSCY2dEstQY7AuxahwXFrvZmWl2rh4JZ07z9dLtesfNj5q0FU3A5ObbwAAAABJRU5ErkJggg==);
+          background-position: top;
+          background-repeat: repeat-x;
+          height: 60px;
+          padding-bottom: 50px;
+          width: 100%;
+          transition: all 0.2s cubic-bezier(0, 0, 0.2, 1);
+          z-index: 1;
+        }
+        /* play button */
+        .lvo-playbtn {
+          width: 70px;
+          height: 46px;
+          background-color: #212121;
+          z-index: 1;
+          opacity: 0.8;
+          border-radius: 10%;
+          transition: all 0.2s cubic-bezier(0, 0, 0.2, 1);
+          border: 0;
+        }
+        #frame:hover .lvo-playbtn {
+          background-color: rgb(98, 175, 237);
+          opacity: 1;
+        }
+        /* play button triangle */
+        .lvo-playbtn:before {
+          content: '';
+          border-style: solid;
+          border-width: 11px 0 11px 19px;
+          border-color: transparent transparent transparent #fff;
+        }
+        .lvo-playbtn,
+        .lvo-playbtn:before {
+          position: absolute;
+          top: 50%;
+          left: 50%;
+          transform: translate3d(-50%, -50%, 0);
+        }
+
+        /* Post-click styles */
+        .lvo-activated {
+          cursor: unset;
+        }
+
+        #frame.lvo-activated::before,
+        .lvo-activated .lvo-playbtn {
+          display: none;
+        }
+      </style>
+      <div id="frame" part="frame">
+        <picture part="picture-frame">
+          <source id="webpPlaceholder" type="image/webp">
+          <source id="jpegPlaceholder" type="image/jpeg">
+          <img id="fallbackPlaceholder"
+               referrerpolicy="origin"
+               width="1100"
+               height="619"
+               decoding="async"
+               loading="lazy"
+               part="picture">
+        </picture>
+        <button class="lvo-playbtn" part="play-button"></button>
+      </div>
+    `;
+      this.domRefFrame = this.shadowRoot.querySelector("#frame");
+      this.domRefImg = {
+        fallback: this.shadowRoot.querySelector("#fallbackPlaceholder"),
+        webp: this.shadowRoot.querySelector("#webpPlaceholder"),
+        jpeg: this.shadowRoot.querySelector("#jpegPlaceholder")
+      };
+      this.domRefPlayButton = this.shadowRoot.querySelector(".lvo-playbtn");
+    }
+    /**
+     * Parse our attributes and fire up some placeholders
+     */
+    setupComponent() {
+      this.initImagePlaceholder();
+      this.domRefPlayButton.setAttribute("aria-label", `${this.videoPlay}: ${this.videoTitle}`);
+      this.setAttribute("title", `${this.videoPlay}: ${this.videoTitle}`);
+      if (this.autoLoad) {
+        this.initIntersectionObserver();
+      }
+    }
+    /**
+     * Lifecycle method that we use to listen for attribute changes to period
+     * @param {*} name
+     * @param {*} oldVal
+     * @param {*} newVal
+     */
+    attributeChangedCallback(name, oldVal, newVal) {
+      switch (name) {
+        case "videoid": {
+          if (oldVal !== newVal) {
+            this.setupComponent();
+            if (this.domRefFrame.classList.contains("lvo-activated")) {
+              this.domRefFrame.classList.remove("lvo-activated");
+              this.shadowRoot.querySelector("iframe").remove();
+            }
+          }
+          break;
+        }
+        default:
+          break;
+      }
+    }
+    /**
+     * Inject the iframe into the component body
+     */
+    addIframe() {
+      if (!this.iframeLoaded) {
+        const apValue = this.autoLoad && this.autoPlay || !this.autoLoad ? "autoplay=1" : "";
+        const srcUrl = new URL(`/video/${this.videoId}?${apValue}&#t=${this.videoStartAt}`, "https://player.vimeo.com/");
+        const iframeHTML = `
+<iframe frameborder="0"
+  allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+  allowfullscreen src="${srcUrl}"></iframe>`;
+        this.domRefFrame.insertAdjacentHTML("beforeend", iframeHTML);
+        this.domRefFrame.classList.add("lvo-activated");
+        this.iframeLoaded = true;
+      }
+    }
+    /**
+     * Setup the placeholder image for the component
+     */
+    async initImagePlaceholder() {
+      _LiteVimeoEmbed.addPrefetch("preconnect", "https://i.vimeocdn.com/");
+      const apiUrl = `https://vimeo.com/api/v2/video/${this.videoId}.json`;
+      const apiResponse = (await (await fetch(apiUrl)).json())[0];
+      const tnLarge = apiResponse.thumbnail_large;
+      const imgId = tnLarge.substr(tnLarge.lastIndexOf("/") + 1).split("_")[0];
+      const posterUrlWebp = `https://i.vimeocdn.com/video/${imgId}.webp?mw=1100&mh=619&q=70`;
+      const posterUrlJpeg = `https://i.vimeocdn.com/video/${imgId}.jpg?mw=1100&mh=619&q=70`;
+      this.domRefImg.webp.srcset = posterUrlWebp;
+      this.domRefImg.jpeg.srcset = posterUrlJpeg;
+      this.domRefImg.fallback.src = posterUrlJpeg;
+      this.domRefImg.fallback.setAttribute("aria-label", `${this.videoPlay}: ${this.videoTitle}`);
+      this.domRefImg.fallback.setAttribute("alt", `${this.videoPlay}: ${this.videoTitle}`);
+    }
+    /**
+     * Setup the Intersection Observer to load the iframe when scrolled into view
+     */
+    initIntersectionObserver() {
+      if ("IntersectionObserver" in window && "IntersectionObserverEntry" in window) {
+        const options = {
+          root: null,
+          rootMargin: "0px",
+          threshold: 0
+        };
+        const observer = new IntersectionObserver((entries, observer2) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting && !this.iframeLoaded) {
+              _LiteVimeoEmbed.warmConnections();
+              this.addIframe();
+              observer2.unobserve(this);
+            }
+          });
+        }, options);
+        observer.observe(this);
+      }
+    }
+    /**
+     * Add a <link rel={preload | preconnect} ...> to the head
+     * @param {*} kind
+     * @param {*} url
+     * @param {*} as
+     */
+    static addPrefetch(kind, url, as) {
+      const linkElem = document.createElement("link");
+      linkElem.rel = kind;
+      linkElem.href = url;
+      if (as) {
+        linkElem.as = as;
+      }
+      linkElem.crossOrigin = "true";
+      document.head.append(linkElem);
+    }
+    /**
+     * Begin preconnecting to warm up the iframe load Since the embed's netwok
+     * requests load within its iframe, preload/prefetch'ing them outside the
+     * iframe will only cause double-downloads. So, the best we can do is warm up
+     * a few connections to origins that are in the critical path.
+     *
+     * Maybe `<link rel=preload as=document>` would work, but it's unsupported:
+     * http://crbug.com/593267 But TBH, I don't think it'll happen soon with Site
+     * Isolation and split caches adding serious complexity.
+     */
+    static warmConnections() {
+      if (_LiteVimeoEmbed.preconnected) return;
+      _LiteVimeoEmbed.addPrefetch("preconnect", "https://f.vimeocdn.com");
+      _LiteVimeoEmbed.addPrefetch("preconnect", "https://player.vimeo.com");
+      _LiteVimeoEmbed.addPrefetch("preconnect", "https://i.vimeocdn.com");
+      _LiteVimeoEmbed.preconnected = true;
+    }
+  };
+  _LiteVimeoEmbed.preconnected = false;
+  var LiteVimeoEmbed = _LiteVimeoEmbed;
+  customElements.define("lite-vimeo", LiteVimeoEmbed);
+})();

--- a/vendor/lite-youtube/README.md
+++ b/vendor/lite-youtube/README.md
@@ -22,6 +22,9 @@
 - _new in v1.3_: Adds `loading=lazy` to image placeholder for more perf with `posterloading` attr if you'd like to use eager
 - _new in v1.4_: Adds `short` attr for enabling experimental YouTube Shorts mobile interaction support. See (example video)[https://www.youtube.com/watch?v=aw7CRQTuRfo] for details.
 - _new in v1.5_: Adds support for nonce attribute via `window.liteYouTubeNonce` for CSP 2/3 support.
+- _new in v1.6_: Adds `autoPause` for pausing videos scrolled off screen; adds `--lite-youtube-aspect-ratio` CSS custom property create custom aspect ratio videos; adds `--lite-youtube-frame-shadow-visible` CSS custom property to disable frame shadow (flat look); adds a named slot `image` that allows for setting custom poster image; adds `credentialless` for COEP
+- _new in v1.7_: Adds support for 404 fallback posters; add noscript injector to lightdom for search indexing (disable via `disablenoscript` attribute in v1.7.1).
+- _new in v1.8_: Adds support for styling the play button via `::part` (thank you [@Lukinoh](https://github.com/Lukinoh)!).
 
 ## Install via package manager
 
@@ -47,7 +50,7 @@ import '@justinribeiro/lite-youtube';
 If you want the paste-and-go version, you can simply load it via CDN:
 
 ```html
-<script type="module" src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.5.0/lite-youtube.js"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1/lite-youtube.min.js"></script>
 ```
 
 ## Basic Usage
@@ -182,6 +185,56 @@ Uses Intersection Observer if available to automatically load the YouTube iframe
   videoid="guJLfqTFfIw"
   posterquality="maxresdefault"
 ></lite-youtube>
+```
+
+## Use the named slot to set a custom poster image
+```html
+<lite-youtube videoid="guJLfqTFfIw">
+  <img slot="image" src="my-poster-override.jpg">
+</lite-youtube>
+```
+
+## Set custom aspect ratio
+```html
+<style>
+  lite-youtube {
+    --lite-youtube-aspect-ratio: 2 / 3;
+  }
+</style>
+<lite-youtube videoid="guJLfqTFfIw"></lite-youtube>
+```
+
+## Disable the frame shadow (flat look)
+```html
+<style>
+  lite-youtube {
+    /* No Shadow */
+    --lite-youtube-frame-shadow-visible: no;
+  }
+</style>
+<lite-youtube videoid="guJLfqTFfIw"></lite-youtube>
+```
+
+## Customize the play button
+```html
+<style>
+  lite-youtube::part(playButton) {
+    /* You custom style */
+  }
+</style>
+<lite-youtube videoid="guJLfqTFfIw"></lite-youtube>
+```
+
+## Auto-Pause video when scrolled out of view
+Note: the custom poster image will load with this set, but will then disappear without any user interaction because of the intersection observer starting.
+```html
+ <lite-youtube videoid="VLrYOji75Vc" autopause></lite-youtube>
+```
+
+## NoScript disable
+As of v1.7.0, we inject into the lightdom a noscript for SEO help. This can conflict with server side rendered noscript injects. To disable, simply pass `disablenoscript` to the component:
+```html
+ <lite-youtube videoid="VLrYOji75Vc" disablenoscript></lite-youtube>
 ```
 
 ## YouTube QueryParams

--- a/vendor/lite-youtube/lite-youtube.js
+++ b/vendor/lite-youtube/lite-youtube.js
@@ -98,6 +98,7 @@ export class LiteYTEmbed extends HTMLElement {
           width: 100%;
           height: 100%;
           left: 0;
+          top: 0;
         }
 
         #frame {

--- a/vendor/lite-youtube/lite-youtube.js
+++ b/vendor/lite-youtube/lite-youtube.js
@@ -1,82 +1,95 @@
 export class LiteYTEmbed extends HTMLElement {
-	constructor() {
-		super();
-		this.isIframeLoaded = false;
-		this.setupDom();
-	}
-	static get observedAttributes() {
-		return ["videoid", "playlistid"];
-	}
-	connectedCallback() {
-		this.addEventListener("pointerover", LiteYTEmbed.warmConnections, {
-			once: true,
-		});
-		this.addEventListener("click", () => this.addIframe());
-	}
-	get videoId() {
-		return encodeURIComponent(this.getAttribute("videoid") || "");
-	}
-	set videoId(id) {
-		this.setAttribute("videoid", id);
-	}
-	get playlistId() {
-		return encodeURIComponent(this.getAttribute("playlistid") || "");
-	}
-	set playlistId(id) {
-		this.setAttribute("playlistid", id);
-	}
-	get videoTitle() {
-		return this.getAttribute("videotitle") || "Video";
-	}
-	set videoTitle(title) {
-		this.setAttribute("videotitle", title);
-	}
-	get videoPlay() {
-		return this.getAttribute("videoPlay") || "Play";
-	}
-	set videoPlay(name) {
-		this.setAttribute("videoPlay", name);
-	}
-	get videoStartAt() {
-		return this.getAttribute("videoStartAt") || "0";
-	}
-	get autoLoad() {
-		return this.hasAttribute("autoload");
-	}
-	get noCookie() {
-		return this.hasAttribute("nocookie");
-	}
-	get posterQuality() {
-		return this.getAttribute("posterquality") || "hqdefault";
-	}
-	get posterLoading() {
-		return this.getAttribute("posterloading") || "lazy";
-	}
-	get params() {
-		return `start=${this.videoStartAt}&${this.getAttribute("params")}`;
-	}
-	set params(opts) {
-		this.setAttribute("params", opts);
-	}
-	setupDom() {
-		const shadowDom = this.attachShadow({ mode: "open" });
-		let nonce = "";
-		if (window.liteYouTubeNonce) {
-			nonce = `nonce="${window.liteYouTubeNonce}"`;
-		}
-		shadowDom.innerHTML = `
+    constructor() {
+        super();
+        this.isIframeLoaded = false;
+        this.setupDom();
+    }
+    static get observedAttributes() {
+        return ['videoid', 'playlistid', 'videoplay', 'videotitle'];
+    }
+    connectedCallback() {
+        this.addEventListener('pointerover', () => LiteYTEmbed.warmConnections(this), {
+            once: true,
+        });
+        this.addEventListener('click', () => this.addIframe());
+    }
+    get videoId() {
+        return encodeURIComponent(this.getAttribute('videoid') || '');
+    }
+    set videoId(id) {
+        this.setAttribute('videoid', id);
+    }
+    get playlistId() {
+        return encodeURIComponent(this.getAttribute('playlistid') || '');
+    }
+    set playlistId(id) {
+        this.setAttribute('playlistid', id);
+    }
+    get videoTitle() {
+        return this.getAttribute('videotitle') || 'Video';
+    }
+    set videoTitle(title) {
+        this.setAttribute('videotitle', title);
+    }
+    get videoPlay() {
+        return this.getAttribute('videoplay') || 'Play';
+    }
+    set videoPlay(name) {
+        this.setAttribute('videoplay', name);
+    }
+    get videoStartAt() {
+        return this.getAttribute('videoStartAt') || '0';
+    }
+    get autoLoad() {
+        return this.hasAttribute('autoload');
+    }
+    get autoPause() {
+        return this.hasAttribute('autopause');
+    }
+    get noCookie() {
+        return this.hasAttribute('nocookie');
+    }
+    get posterQuality() {
+        return this.getAttribute('posterquality') || 'hqdefault';
+    }
+    get posterLoading() {
+        return (this.getAttribute('posterloading') ||
+            'lazy');
+    }
+    get params() {
+        return `start=${this.videoStartAt}&${this.getAttribute('params')}`;
+    }
+    set params(opts) {
+        this.setAttribute('params', opts);
+    }
+    set posterQuality(opts) {
+        this.setAttribute('posterquality', opts);
+    }
+    get disableNoscript() {
+        return this.hasAttribute('disablenoscript');
+    }
+    setupDom() {
+        const shadowDom = this.attachShadow({ mode: 'open' });
+        let nonce = '';
+        if (window.liteYouTubeNonce) {
+            nonce = `nonce="${window.liteYouTubeNonce}"`;
+        }
+        shadowDom.innerHTML = `
       <style ${nonce}>
         :host {
+          --aspect-ratio: var(--lite-youtube-aspect-ratio, 16 / 9);
+          --aspect-ratio-short: var(--lite-youtube-aspect-ratio-short, 9 / 16);
+          --frame-shadow-visible: var(--lite-youtube-frame-shadow-visible, yes);
           contain: content;
           display: block;
           position: relative;
           width: 100%;
-          padding-bottom: calc(100% / (16 / 9));
+          aspect-ratio: var(--aspect-ratio);
         }
 
         @media (max-width: 40em) {
           :host([short]) {
-            padding-bottom: calc(100% / (9 / 16));
+            aspect-ratio: var(--aspect-ratio-short);
           }
         }
 
@@ -91,19 +104,22 @@ export class LiteYTEmbed extends HTMLElement {
           cursor: pointer;
         }
 
-        #fallbackPlaceholder {
+        #fallbackPlaceholder, slot[name=image]::slotted(*) {
           object-fit: cover;
+          width: 100%;
         }
 
-        #frame::before {
-          content: '';
-          display: block;
-          position: absolute;
-          top: 0;
-          background-image: linear-gradient(180deg, #111 -20%, transparent 90%);
-          height: 60px;
-          width: 100%;
-          z-index: 1;
+        @container style(--frame-shadow-visible: yes) {
+          #frame::before {
+            content: '';
+            display: block;
+            position: absolute;
+            top: 0;
+            background-image: linear-gradient(180deg, #111 -20%, transparent 90%);
+            height: 60px;
+            width: 100%;
+            z-index: 1;
+          }
         }
 
         #playButton {
@@ -144,171 +160,186 @@ export class LiteYTEmbed extends HTMLElement {
       </style>
       <div id="frame">
         <picture>
-          <source id="webpPlaceholder" type="image/webp">
-          <source id="jpegPlaceholder" type="image/jpeg">
-          <img id="fallbackPlaceholder" referrerpolicy="origin" loading="lazy">
+          <slot name="image">
+            <source id="webpPlaceholder" type="image/webp">
+            <source id="jpegPlaceholder" type="image/jpeg">
+            <img id="fallbackPlaceholder" referrerpolicy="origin" loading="lazy">
+          </slot>
         </picture>
-        <button id="playButton"></button>
+        <button id="playButton" part="playButton"></button>
       </div>
     `;
-		this.domRefFrame = shadowDom.querySelector("#frame");
-		this.domRefImg = {
-			fallback: shadowDom.querySelector("#fallbackPlaceholder"),
-			webp: shadowDom.querySelector("#webpPlaceholder"),
-			jpeg: shadowDom.querySelector("#jpegPlaceholder"),
-		};
-		this.domRefPlayButton = shadowDom.querySelector("#playButton");
-	}
-	setupComponent() {
-		this.initImagePlaceholder();
-		this.domRefPlayButton.setAttribute(
-			"aria-label",
-			`${this.videoPlay}: ${this.videoTitle}`
-		);
-		this.setAttribute("title", `${this.videoPlay}: ${this.videoTitle}`);
-		if (this.autoLoad || this.isYouTubeShort()) {
-			this.initIntersectionObserver();
-		}
-	}
-	attributeChangedCallback(name, oldVal, newVal) {
-		switch (name) {
-			case "videoid":
-			case "playlistid":
-			case "videoTitle":
-			case "videoPlay": {
-				if (oldVal !== newVal) {
-					this.setupComponent();
-					if (this.domRefFrame.classList.contains("activated")) {
-						this.domRefFrame.classList.remove("activated");
-						this.shadowRoot.querySelector("iframe").remove();
-						this.isIframeLoaded = false;
-					}
-				}
-				break;
-			}
-			default:
-				break;
-		}
-	}
-	addIframe(isIntersectionObserver = false) {
-		if (!this.isIframeLoaded) {
-			let autoplay = isIntersectionObserver ? 0 : 1;
-			const wantsNoCookie = this.noCookie ? "-nocookie" : "";
-			let embedTarget;
-			if (this.playlistId) {
-				embedTarget = `?listType=playlist&list=${this.playlistId}&`;
-			} else {
-				embedTarget = `${this.videoId}?`;
-			}
-			if (this.isYouTubeShort()) {
-				this.params = `loop=1&mute=1&modestbranding=1&playsinline=1&rel=0&enablejsapi=1&playlist=${this.videoId}`;
-				autoplay = 1;
-			}
-			const iframeHTML = `
-<iframe frameborder="0" title="${this.videoTitle}"
+        this.domRefFrame = shadowDom.querySelector('#frame');
+        this.domRefImg = {
+            fallback: shadowDom.querySelector('#fallbackPlaceholder'),
+            webp: shadowDom.querySelector('#webpPlaceholder'),
+            jpeg: shadowDom.querySelector('#jpegPlaceholder'),
+        };
+        this.domRefPlayButton = shadowDom.querySelector('#playButton');
+    }
+    setupComponent() {
+        const hasImgSlot = this.shadowRoot.querySelector('slot[name=image]');
+        if (hasImgSlot.assignedNodes().length === 0) {
+            this.initImagePlaceholder();
+        }
+        this.domRefPlayButton.setAttribute('aria-label', `${this.videoPlay}: ${this.videoTitle}`);
+        this.setAttribute('title', `${this.videoPlay}: ${this.videoTitle}`);
+        if (this.autoLoad || this.isYouTubeShort() || this.autoPause) {
+            this.initIntersectionObserver();
+        }
+        if (!this.disableNoscript) {
+            this.injectSearchNoScript();
+        }
+    }
+    attributeChangedCallback(name, oldVal, newVal) {
+        if (oldVal !== newVal) {
+            this.setupComponent();
+            if (this.domRefFrame.classList.contains('activated')) {
+                this.domRefFrame.classList.remove('activated');
+                this.shadowRoot.querySelector('iframe').remove();
+                this.isIframeLoaded = false;
+            }
+        }
+    }
+    injectSearchNoScript() {
+        const eleNoScript = document.createElement('noscript');
+        this.prepend(eleNoScript);
+        eleNoScript.innerHTML = this.generateIframe();
+    }
+    generateIframe(isIntersectionObserver = false) {
+        let autoplay = isIntersectionObserver ? 0 : 1;
+        const wantsNoCookie = this.noCookie ? '-nocookie' : '';
+        let embedTarget;
+        if (this.playlistId) {
+            embedTarget = `?listType=playlist&list=${this.playlistId}&`;
+        }
+        else {
+            embedTarget = `${this.videoId}?`;
+        }
+        if (this.autoPause) {
+            this.params = `enablejsapi=1`;
+        }
+        if (this.isYouTubeShort()) {
+            this.params = `loop=1&mute=1&modestbranding=1&playsinline=1&rel=0&enablejsapi=1&playlist=${this.videoId}`;
+            autoplay = 1;
+        }
+        return `
+<iframe credentialless frameborder="0" title="${this.videoTitle}"
   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen
   src="https://www.youtube${wantsNoCookie}.com/embed/${embedTarget}autoplay=${autoplay}&${this.params}"
 ></iframe>`;
-			this.domRefFrame.insertAdjacentHTML("beforeend", iframeHTML);
-			this.domRefFrame.classList.add("activated");
-			this.isIframeLoaded = true;
-			this.attemptShortAutoPlay();
-			this.dispatchEvent(
-				new CustomEvent("liteYoutubeIframeLoaded", {
-					detail: {
-						videoId: this.videoId,
-					},
-					bubbles: true,
-					cancelable: true,
-				})
-			);
-		}
-	}
-	initImagePlaceholder() {
-		const posterUrlWebp = `https://i.ytimg.com/vi_webp/${this.videoId}/${this.posterQuality}.webp`;
-		const posterUrlJpeg = `https://i.ytimg.com/vi/${this.videoId}/${this.posterQuality}.jpg`;
-		// PATCH: This changes the fallback img src to be the hqdefault quality no matter what since some old videos don't have higher resolution
-		const posterUrlFallback = `https://i.ytimg.com/vi/${this.videoId}/hqdefault.jpg`;
-		this.domRefImg.fallback.loading = this.posterLoading;
-		this.domRefImg.webp.srcset = posterUrlWebp;
-		this.domRefImg.jpeg.srcset = posterUrlJpeg;
-		// PATCH: Change fallback src. See comment on line 230 for reasoning
-		this.domRefImg.fallback.src = posterUrlFallback;
-		this.domRefImg.fallback.setAttribute(
-			"aria-label",
-			`${this.videoPlay}: ${this.videoTitle}`
-		);
-		this.domRefImg?.fallback?.setAttribute(
-			"alt",
-			`${this.videoPlay}: ${this.videoTitle}`
-		);
-		// PATCH: Recursively load picture sources in order, deleting any where the image's natural width indicates that it is the YouTube image fallback placeholder rather than a real video poster.
-		this.domRefImg.fallback.onload = (e) => {
-			if (e.target.naturalWidth === 120) {
-				this.domRefImg.fallback.parentElement.firstElementChild.remove();
-			}
-		};
-	}
-	initIntersectionObserver() {
-		const options = {
-			root: null,
-			rootMargin: "0px",
-			threshold: 0,
-		};
-		const observer = new IntersectionObserver((entries, observer) => {
-			entries.forEach((entry) => {
-				if (entry.isIntersecting && !this.isIframeLoaded) {
-					LiteYTEmbed.warmConnections();
-					this.addIframe(true);
-					observer.unobserve(this);
-				}
-			});
-		}, options);
-		observer.observe(this);
-	}
-	attemptShortAutoPlay() {
-		if (this.isYouTubeShort()) {
-			setTimeout(() => {
-				this.shadowRoot
-					.querySelector("iframe")
-					?.contentWindow?.postMessage(
-						'{"event":"command","func":"' +
-							"playVideo" +
-							'","args":""}',
-						"*"
-					);
-			}, 2000);
-		}
-	}
-	isYouTubeShort() {
-		return (
-			this.getAttribute("short") === "" &&
-			window.matchMedia("(max-width: 40em)").matches
-		);
-	}
-	static addPrefetch(kind, url) {
-		const linkElem = document.createElement("link");
-		linkElem.rel = kind;
-		linkElem.href = url;
-		linkElem.crossOrigin = "true";
-		document.head.append(linkElem);
-	}
-	static warmConnections() {
-		if (LiteYTEmbed.isPreconnected || window.liteYouTubeIsPreconnected)
-			return;
-		LiteYTEmbed.addPrefetch("preconnect", "https://i.ytimg.com/");
-		LiteYTEmbed.addPrefetch("preconnect", "https://s.ytimg.com");
-		LiteYTEmbed.addPrefetch("preconnect", "https://www.youtube.com");
-		LiteYTEmbed.addPrefetch("preconnect", "https://www.google.com");
-		LiteYTEmbed.addPrefetch(
-			"preconnect",
-			"https://googleads.g.doubleclick.net"
-		);
-		LiteYTEmbed.addPrefetch("preconnect", "https://static.doubleclick.net");
-		LiteYTEmbed.isPreconnected = true;
-		window.liteYouTubeIsPreconnected = true;
-	}
+    }
+    addIframe(isIntersectionObserver = false) {
+        if (!this.isIframeLoaded) {
+            const iframeHTML = this.generateIframe(isIntersectionObserver);
+            this.domRefFrame.insertAdjacentHTML('beforeend', iframeHTML);
+            this.domRefFrame.classList.add('activated');
+            this.isIframeLoaded = true;
+            this.attemptShortAutoPlay();
+            this.dispatchEvent(new CustomEvent('liteYoutubeIframeLoaded', {
+                detail: {
+                    videoId: this.videoId,
+                },
+                bubbles: true,
+                cancelable: true,
+            }));
+        }
+    }
+    initImagePlaceholder() {
+        this.testPosterImage();
+        this.domRefImg.fallback.setAttribute('aria-label', `${this.videoPlay}: ${this.videoTitle}`);
+        this.domRefImg?.fallback?.setAttribute('alt', `${this.videoPlay}: ${this.videoTitle}`);
+    }
+    async testPosterImage() {
+        setTimeout(() => {
+            const webpUrl = `https://i.ytimg.com/vi_webp/${this.videoId}/${this.posterQuality}.webp`;
+            const img = new Image();
+            img.fetchPriority = 'low';
+            img.referrerPolicy = 'origin';
+            img.src = webpUrl;
+            img.onload = async (e) => {
+                const target = e.target;
+                const noPoster = target?.naturalHeight == 90 && target?.naturalWidth == 120;
+                if (noPoster) {
+                    this.posterQuality = 'hqdefault';
+                }
+                const posterUrlWebp = `https://i.ytimg.com/vi_webp/${this.videoId}/${this.posterQuality}.webp`;
+                this.domRefImg.webp.srcset = posterUrlWebp;
+                const posterUrlJpeg = `https://i.ytimg.com/vi/${this.videoId}/${this.posterQuality}.jpg`;
+                this.domRefImg.fallback.loading = this.posterLoading;
+                this.domRefImg.jpeg.srcset = posterUrlJpeg;
+                this.domRefImg.fallback.src = posterUrlJpeg;
+                this.domRefImg.fallback.loading = this.posterLoading;
+            };
+        }, 100);
+    }
+    initIntersectionObserver() {
+        const options = {
+            root: null,
+            rootMargin: '0px',
+            threshold: 0,
+        };
+        const observer = new IntersectionObserver((entries, observer) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting && !this.isIframeLoaded) {
+                    LiteYTEmbed.warmConnections(this);
+                    this.addIframe(true);
+                    observer.unobserve(this);
+                }
+            });
+        }, options);
+        observer.observe(this);
+        if (this.autoPause) {
+            const windowPause = new IntersectionObserver((e, o) => {
+                e.forEach(entry => {
+                    if (entry.intersectionRatio !== 1) {
+                        this.shadowRoot
+                            .querySelector('iframe')
+                            ?.contentWindow?.postMessage('{"event":"command","func":"pauseVideo","args":""}', '*');
+                    }
+                });
+            }, { threshold: 1 });
+            windowPause.observe(this);
+        }
+    }
+    attemptShortAutoPlay() {
+        if (this.isYouTubeShort()) {
+            setTimeout(() => {
+                this.shadowRoot
+                    .querySelector('iframe')
+                    ?.contentWindow?.postMessage('{"event":"command","func":"' + 'playVideo' + '","args":""}', '*');
+            }, 2000);
+        }
+    }
+    isYouTubeShort() {
+        return (this.getAttribute('short') === '' &&
+            window.matchMedia('(max-width: 40em)').matches);
+    }
+    static addPrefetch(kind, url) {
+        const linkElem = document.createElement('link');
+        linkElem.rel = kind;
+        linkElem.href = url;
+        linkElem.crossOrigin = 'true';
+        document.head.append(linkElem);
+    }
+    static warmConnections(context) {
+        if (LiteYTEmbed.isPreconnected || window.liteYouTubeIsPreconnected)
+            return;
+        LiteYTEmbed.addPrefetch('preconnect', 'https://i.ytimg.com/');
+        LiteYTEmbed.addPrefetch('preconnect', 'https://s.ytimg.com');
+        if (!context.noCookie) {
+            LiteYTEmbed.addPrefetch('preconnect', 'https://www.youtube.com');
+            LiteYTEmbed.addPrefetch('preconnect', 'https://www.google.com');
+            LiteYTEmbed.addPrefetch('preconnect', 'https://googleads.g.doubleclick.net');
+            LiteYTEmbed.addPrefetch('preconnect', 'https://static.doubleclick.net');
+        }
+        else {
+            LiteYTEmbed.addPrefetch('preconnect', 'https://www.youtube-nocookie.com');
+        }
+        LiteYTEmbed.isPreconnected = true;
+        window.liteYouTubeIsPreconnected = true;
+    }
 }
 LiteYTEmbed.isPreconnected = false;
-customElements.define("lite-youtube", LiteYTEmbed);
+customElements.define('lite-youtube', LiteYTEmbed);
 //# sourceMappingURL=lite-youtube.js.map


### PR DESCRIPTION
- Add support for Vimeo!
- Upgrade `lite-youtube` to 1.8.1 (includes new native support for fallback thumbnail formats and sizes)
- Further performance improvements to load script asynchronously and only load styles when needed
- Fix undefined `$params` fatal error when trying to extract time code from YouTube URLs
- Code quality improvements